### PR TITLE
Fix broken YouTube demo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For a quick and comprehensive walkthrough, watch our **YouTube demo video**:
 
 [![Demo Video](https://img.youtube.com/vi/jawnA9mwhck/0.jpg)](https://www.youtube.com/watch?v=jawnA9mwhck)
 
-*Click on the image above or [this link](https://youtu.be/k5L0-gZzzkc?si=jawnA9mwhck) to view the demo.*
+*Click on the image above or [this link](https://www.youtube.com/watch?v=jawnA9mwhck) to view the demo.*
 
 ---
 


### PR DESCRIPTION
Fix demo video link in README to point to the correct YouTube video

The previous link to the demo video pointed to a different YouTube video ID (`k5L0-gZzzkc`). I updated it to match the correct video ID shown in the thumbnail (`jawnA9mwhck`), ensuring consistency and preventing confusion for users.

This change improves the user experience by linking directly to the correct demo video.